### PR TITLE
Update outputHash in flake.nix

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -78,7 +78,7 @@
         '';
 
         outputHashMode = "recursive";
-        outputHash = "sha256-BMW+oUGHohnWna99M9qqVtOw/K0J/m+C8UEhV//jb1Q=";
+        outputHash = "sha256-m2uGEBzRnOyWWoIfgIgmtPvfl4TP29xKIGsKirRF/8U=";
       };
 
       # Build frontend separately


### PR DESCRIPTION
This pull request makes a minor update to the `flake.nix` file, changing the `outputHash` value for pnpm dependencies. This is likely due to an upstream update or a change in the dependency's contents. No functional or structural changes to the codebase are introduced.